### PR TITLE
Add Microsoft Store MSIX packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,11 +132,25 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           uv run python scripts/release/verify_packaged_gui.py --binary-dir "$output/payload" --settings-smoke
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $msixArguments = @(
+            "scripts/release/build_msix.py",
+            "--payload-root", "$output/payload",
+            "--config", (Resolve-Path "release/windows-store-msix.v1.json").Path,
+            "--source-version", $env:RELEASE_VERSION,
+            "--output-root", $output,
+            "--work-root", (Join-Path $env:RUNNER_TEMP "docwen-msix-work"),
+            "--metadata-output", "$output/DocWen-windows-x64.msix.json"
+          )
+          & $python @msixArguments
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Upload clean Windows build evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docwen-windows-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.replica }}
-          path: ${{ runner.temp }}/docwen-candidate/DocWen-windows-x64.zip
+          path: |
+            ${{ runner.temp }}/docwen-candidate/DocWen-windows-x64.zip
+            ${{ runner.temp }}/docwen-candidate/DocWen-windows-x64.msix
+            ${{ runner.temp }}/docwen-candidate/DocWen-windows-x64.msix.json
           compression-level: 0
           if-no-files-found: error
           overwrite: false
@@ -251,6 +265,24 @@ jobs:
         run: |
           set -euo pipefail
           cmp builds/windows-a/DocWen-windows-x64.zip builds/windows-b/DocWen-windows-x64.zip
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          records = []
+          for replica in ("a", "b"):
+              root = Path(f"builds/windows-{replica}")
+              package = root / "DocWen-windows-x64.msix"
+              record = json.loads((root / "DocWen-windows-x64.msix.json").read_text(encoding="utf-8"))
+              actual_sha256 = hashlib.file_digest(package.open("rb"), "sha256").hexdigest()
+              if record["sha256"] != actual_sha256:
+                  raise SystemExit(f"MSIX raw digest mismatch for Windows build {replica}")
+              record.pop("sha256")
+              records.append(record)
+          if records[0] != records[1]:
+              raise SystemExit("independent MSIX package contents differ")
+          PY
           cmp "builds/linux-a/DocWenCLI-${RELEASE_VERSION}-linux-x64.tar.gz" "builds/linux-b/DocWenCLI-${RELEASE_VERSION}-linux-x64.tar.gz"
           cmp "builds/linux-a/DocWen-${RELEASE_VERSION}-linux-x64.tar.gz" "builds/linux-b/DocWen-${RELEASE_VERSION}-linux-x64.tar.gz"
           mkdir publication
@@ -262,6 +294,17 @@ jobs:
             sha256sum DocWen-windows-x64.zip "DocWenCLI-${RELEASE_VERSION}-linux-x64.tar.gz" "DocWen-${RELEASE_VERSION}-linux-x64.tar.gz" > SHA256SUMS.txt
             test "$(find . -maxdepth 1 -type f | wc -l)" -eq 4
           )
+      - name: Upload Microsoft Store submission package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: docwen-microsoft-store-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            builds/windows-a/DocWen-windows-x64.msix
+            builds/windows-a/DocWen-windows-x64.msix.json
+          compression-level: 0
+          if-no-files-found: error
+          overwrite: false
+          retention-days: 30
       - name: Upload the sole current-run publication artifact
         if: github.event_name == 'push'
         id: publication

--- a/release/windows-store-msix.v1.json
+++ b/release/windows-store-msix.v1.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "storeId": "9NR2211SJH97",
+  "sourceVersion": "0.9.0",
+  "packageVersion": "1.0.1.0",
+  "identity": {
+    "name": "ZHYX.DocWen",
+    "publisher": "CN=9E46E7F1-F057-4B88-BF71-7C9CB77AF9C6",
+    "publisherDisplayName": "ZHYX"
+  },
+  "application": {
+    "id": "DocWen",
+    "displayName": "DocWen",
+    "description": "Offline document conversion and formatting tools.",
+    "executable": "DocWen.exe",
+    "cliExecutable": "DocWenCLI.exe",
+    "cliAlias": "docwen.exe"
+  },
+  "target": {
+    "architecture": "x64",
+    "minVersion": "10.0.17763.0",
+    "maxVersionTested": "10.0.26100.0"
+  },
+  "languages": [
+    "zh-CN",
+    "en-US"
+  ],
+  "excludedPayloadPaths": [
+    "_internal/docx/templates/default-docx-template"
+  ],
+  "assetName": "DocWen-windows-x64.msix",
+  "reproducibilityEpoch": 1704067200
+}

--- a/scripts/build/build.py
+++ b/scripts/build/build.py
@@ -109,6 +109,47 @@ def _pyinstaller_output_args() -> list[str]:
     ]
 
 
+@contextlib.contextmanager
+def _isolated_pyinstaller_path():
+    """Keep unrelated native toolchains from contaminating Windows payloads.
+
+    PyInstaller resolves transitive DLL names through ``PATH``. Developer
+    shells commonly prepend Poppler, Qt, or media toolchains whose DLLs can
+    share names with Windows system libraries. The frozen program would then
+    bundle whichever unrelated copy happened to appear first.
+    """
+
+    if not IS_WINDOWS:
+        yield
+        return
+
+    original_path = os.environ.get("PATH")
+    system_root = Path(os.environ.get("SYSTEMROOT", r"C:\Windows"))
+    candidates = (
+        Path(sys.executable).resolve().parent,
+        Path(sys.base_prefix).resolve(),
+        Path(sys.base_prefix).resolve() / "DLLs",
+        system_root / "System32",
+        system_root,
+    )
+    safe_entries: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = os.path.normcase(str(candidate))
+        if candidate.is_dir() and normalized not in seen:
+            safe_entries.append(str(candidate))
+            seen.add(normalized)
+
+    os.environ["PATH"] = os.pathsep.join(safe_entries)
+    try:
+        yield
+    finally:
+        if original_path is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = original_path
+
+
 # Workspace package source roots used by PyInstaller.
 _PACKAGES_DIR = PROJECT_ROOT / "packages"
 _PACKAGE_SRC_DIRS: list[Path] = sorted(
@@ -888,7 +929,8 @@ def build_app(
     try:
         if with_gui:
             logger.info("开始 PyInstaller 构建 (GUI)...")
-            pyinstaller_main.run(gui_build_args)
+            with _isolated_pyinstaller_path():
+                pyinstaller_main.run(gui_build_args)
             _verify_pyinstaller_runtime_hook_order("DocWen", entry_name="pyi_gui_entry")
             logger.info("PyInstaller GUI 构建成功完成!")
         logger.end_step()
@@ -931,7 +973,8 @@ def build_app(
             ]
             for data_file in data_files:
                 cli_build_args.append(f"--add-data={data_file}")
-            pyinstaller_main.run(cli_build_args)
+            with _isolated_pyinstaller_path():
+                pyinstaller_main.run(cli_build_args)
             _verify_pyinstaller_runtime_hook_order("DocWenCLI", entry_name="pyi_cli_entry")
             logger.info("PyInstaller CLI 构建成功完成!")
             logger.end_step()

--- a/scripts/release/build_msix.py
+++ b/scripts/release/build_msix.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Build the unsigned Microsoft Store MSIX from a verified Windows payload.
+
+The Store signs an accepted package. This script deliberately does not create
+or manage a local signing identity; it binds the package to the exact identity
+reserved in Partner Center and emits deterministic submission metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import zipfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+from xml.sax.saxutils import escape, quoteattr
+
+from PIL import Image
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+_FOUR_PART_VERSION = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+_ASSET_SIZES = {
+    "StoreLogo.png": (50, 50),
+    "Square44x44Logo.png": (44, 44),
+    "Square150x150Logo.png": (150, 150),
+}
+
+
+class MsixBuildError(RuntimeError):
+    """A stable, fail-closed MSIX build error."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise MsixBuildError(message)
+
+
+def _as_object(value: object, label: str) -> dict[str, Any]:
+    _require(isinstance(value, dict), f"msix_config_{label}_invalid")
+    return cast(dict[str, Any], value)
+
+
+def _as_text(value: object, label: str) -> str:
+    _require(isinstance(value, str) and bool(value.strip()), f"msix_config_{label}_invalid")
+    return cast(str, value)
+
+
+def validate_package_version(value: str) -> tuple[int, int, int, int]:
+    """Validate the Store's four-part package version contract."""
+
+    _require(_FOUR_PART_VERSION.fullmatch(value) is not None, "msix_package_version_format")
+    parts = tuple(int(part) for part in value.split("."))
+    _require(len(parts) == 4, "msix_package_version_format")
+    _require(all(0 <= part <= 65535 for part in parts), "msix_package_version_range")
+    _require(parts[0] != 0, "msix_package_version_major_zero")
+    _require(parts[3] == 0, "msix_package_version_revision_nonzero")
+    return parts  # type: ignore[return-value]
+
+
+def read_config(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MsixBuildError("msix_config_unreadable") from exc
+
+    config = _as_object(raw, "root")
+    expected_keys = {
+        "schemaVersion",
+        "storeId",
+        "sourceVersion",
+        "packageVersion",
+        "identity",
+        "application",
+        "target",
+        "languages",
+        "excludedPayloadPaths",
+        "assetName",
+        "reproducibilityEpoch",
+    }
+    _require(set(config) == expected_keys, "msix_config_keys")
+    _require(config["schemaVersion"] == 1, "msix_config_schema_version")
+    _require(_as_text(config["storeId"], "store_id") == "9NR2211SJH97", "msix_config_store_id")
+
+    source_version = _as_text(config["sourceVersion"], "source_version")
+    _require(_SEMVER.fullmatch(source_version) is not None, "msix_config_source_version")
+    validate_package_version(_as_text(config["packageVersion"], "package_version"))
+
+    identity = _as_object(config["identity"], "identity")
+    _require(set(identity) == {"name", "publisher", "publisherDisplayName"}, "msix_config_identity_keys")
+    _require(_as_text(identity["name"], "identity_name") == "ZHYX.DocWen", "msix_config_identity_name")
+    _require(
+        _as_text(identity["publisher"], "identity_publisher") == "CN=9E46E7F1-F057-4B88-BF71-7C9CB77AF9C6",
+        "msix_config_identity_publisher",
+    )
+    _as_text(identity["publisherDisplayName"], "publisher_display_name")
+
+    application = _as_object(config["application"], "application")
+    _require(
+        set(application) == {"id", "displayName", "description", "executable", "cliExecutable", "cliAlias"},
+        "msix_config_application_keys",
+    )
+    for key in application:
+        _as_text(application[key], f"application_{key}")
+    _require(
+        str(application["executable"]).casefold() != str(application["cliExecutable"]).casefold(), "msix_exes_distinct"
+    )
+    _require(str(application["cliAlias"]).casefold().endswith(".exe"), "msix_cli_alias_extension")
+
+    target = _as_object(config["target"], "target")
+    _require(set(target) == {"architecture", "minVersion", "maxVersionTested"}, "msix_config_target_keys")
+    _require(target["architecture"] == "x64", "msix_config_architecture")
+    _as_text(target["minVersion"], "min_version")
+    _as_text(target["maxVersionTested"], "max_version_tested")
+
+    languages = config["languages"]
+    _require(isinstance(languages, list) and languages == ["zh-CN", "en-US"], "msix_config_languages")
+    excluded = config["excludedPayloadPaths"]
+    _require(
+        excluded == ["_internal/docx/templates/default-docx-template"],
+        "msix_config_excluded_payload_paths",
+    )
+    _require(_as_text(config["assetName"], "asset_name").endswith(".msix"), "msix_config_asset_name")
+    epoch = config["reproducibilityEpoch"]
+    _require(isinstance(epoch, int) and epoch > 0, "msix_config_reproducibility_epoch")
+    return config
+
+
+def render_manifest(config: Mapping[str, Any]) -> str:
+    identity = config["identity"]
+    application = config["application"]
+    target = config["target"]
+    resources = "\n".join(f"    <Resource Language={quoteattr(str(language))} />" for language in config["languages"])
+    values = {
+        "identity_name": quoteattr(str(identity["name"])),
+        "publisher": quoteattr(str(identity["publisher"])),
+        "package_version": quoteattr(str(config["packageVersion"])),
+        "architecture": quoteattr(str(target["architecture"])),
+        "display_name": escape(str(application["displayName"])),
+        "publisher_display_name": escape(str(identity["publisherDisplayName"])),
+        "min_version": quoteattr(str(target["minVersion"])),
+        "max_version": quoteattr(str(target["maxVersionTested"])),
+        "application_id": quoteattr(str(application["id"])),
+        "executable": quoteattr(str(application["executable"])),
+        "description": quoteattr(str(application["description"])),
+        "cli_executable": quoteattr(str(application["cliExecutable"])),
+        "cli_alias": quoteattr(str(application["cliAlias"])),
+    }
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+  xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap5 desktop4 rescap">
+  <Identity Name={values["identity_name"]} Publisher={values["publisher"]}
+    Version={values["package_version"]} ProcessorArchitecture={values["architecture"]} />
+  <Properties>
+    <DisplayName>{values["display_name"]}</DisplayName>
+    <PublisherDisplayName>{values["publisher_display_name"]}</PublisherDisplayName>
+    <Logo>assets\\msix\\StoreLogo.png</Logo>
+  </Properties>
+  <Resources>
+{resources}
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion={values["min_version"]}
+      MaxVersionTested={values["max_version"]} />
+  </Dependencies>
+  <Applications>
+    <Application Id={values["application_id"]} Executable={values["executable"]}
+      EntryPoint="Windows.FullTrustApplication" desktop4:SupportsMultipleInstances="true">
+      <uap:VisualElements DisplayName={quoteattr(str(application["displayName"]))}
+        Description={values["description"]} BackgroundColor="transparent"
+        Square150x150Logo="assets\\msix\\Square150x150Logo.png"
+        Square44x44Logo="assets\\msix\\Square44x44Logo.png" />
+      <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias" Executable={values["cli_executable"]}
+          EntryPoint="Windows.FullTrustApplication">
+          <uap5:AppExecutionAlias desktop4:Subsystem="console">
+            <uap5:ExecutionAlias Alias={values["cli_alias"]} />
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>
+"""
+
+
+def _copy_payload(payload_root: Path, staging_root: Path, config: Mapping[str, Any]) -> None:
+    _require(payload_root.is_dir(), "msix_payload_root_missing")
+    _require(not (payload_root / "AppxManifest.xml").exists(), "msix_payload_manifest_preexisting")
+    application = config["application"]
+    for executable_key in ("executable", "cliExecutable"):
+        _require((payload_root / application[executable_key]).is_file(), f"msix_payload_{executable_key}_missing")
+
+    for source in payload_root.rglob("*"):
+        _require(not source.is_symlink(), "msix_payload_links_forbidden")
+    shutil.copytree(payload_root, staging_root)
+
+    for relative_text in config["excludedPayloadPaths"]:
+        relative = PurePosixPath(relative_text)
+        _require(not relative.is_absolute() and ".." not in relative.parts, "msix_excluded_payload_path_invalid")
+        excluded_path = staging_root.joinpath(*relative.parts)
+        _require(excluded_path.is_dir() and not excluded_path.is_symlink(), "msix_excluded_payload_path_missing")
+        shutil.rmtree(excluded_path)
+    _require(
+        (staging_root / "_internal" / "docx" / "templates" / "default.docx").is_file(),
+        "msix_default_docx_missing",
+    )
+
+
+def _write_assets(staging_root: Path) -> None:
+    candidates = (staging_root / "assets" / "icon.png", _REPO_ROOT / "assets" / "icon.png")
+    icon_path = next((path for path in candidates if path.is_file()), None)
+    _require(icon_path is not None, "msix_icon_source_missing")
+    icon_path = cast(Path, icon_path)
+    output_root = staging_root / "assets" / "msix"
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    with Image.open(icon_path) as source:
+        icon = source.convert("RGBA")
+        for name, size in _ASSET_SIZES.items():
+            resized = icon.resize(size, Image.Resampling.LANCZOS)
+            resized.save(output_root / name, format="PNG", optimize=False, compress_level=9)
+
+
+def _sanitize_stripped_pe_certificates(staging_root: Path) -> tuple[str, ...]:
+    """Clear certificate table pointers whose signature bytes were stripped.
+
+    Some standalone CPython distributions retain a PE security-directory entry
+    after removing the certificate blob from Tcl/Tk DLLs. Windows can execute
+    those DLLs, but SignTool refuses to sign any MSIX containing them with
+    ``0x800700C1``. Clearing an entry is safe only when it starts exactly at EOF;
+    any other malformed certificate table fails closed.
+    """
+
+    sanitized: list[str] = []
+    for path in sorted(candidate for candidate in staging_root.rglob("*") if candidate.is_file()):
+        file_size = path.stat().st_size
+        if file_size < 64:
+            continue
+        with path.open("rb") as stream:
+            if stream.read(2) != b"MZ":
+                continue
+            stream.seek(0x3C)
+            pe_offset_bytes = stream.read(4)
+            _require(len(pe_offset_bytes) == 4, "msix_pe_header_truncated")
+            pe_offset = struct.unpack("<I", pe_offset_bytes)[0]
+            _require(pe_offset + 24 <= file_size, "msix_pe_header_invalid")
+            stream.seek(pe_offset)
+            _require(stream.read(4) == b"PE\0\0", "msix_pe_signature_invalid")
+            coff_header = stream.read(20)
+            _require(len(coff_header) == 20, "msix_pe_header_truncated")
+            optional_size = struct.unpack_from("<H", coff_header, 16)[0]
+            optional_offset = pe_offset + 24
+            _require(optional_offset + optional_size <= file_size, "msix_pe_optional_header_invalid")
+            stream.seek(optional_offset)
+            magic_bytes = stream.read(2)
+            _require(len(magic_bytes) == 2, "msix_pe_optional_header_truncated")
+            magic = struct.unpack("<H", magic_bytes)[0]
+            if magic == 0x10B:
+                data_directory_offset = 96
+                directory_count_offset = 92
+            elif magic == 0x20B:
+                data_directory_offset = 112
+                directory_count_offset = 108
+            else:
+                raise MsixBuildError("msix_pe_optional_header_magic")
+            _require(
+                optional_size >= directory_count_offset + 4,
+                "msix_pe_optional_header_directories_missing",
+            )
+            stream.seek(optional_offset + directory_count_offset)
+            directory_count = struct.unpack("<I", stream.read(4))[0]
+            if directory_count <= 4:
+                continue
+            security_entry_offset = optional_offset + data_directory_offset + (4 * 8)
+            _require(
+                security_entry_offset + 8 <= optional_offset + optional_size,
+                "msix_pe_security_directory_missing",
+            )
+            stream.seek(security_entry_offset)
+            certificate_offset, certificate_size = struct.unpack("<II", stream.read(8))
+
+        if certificate_offset == 0 and certificate_size == 0:
+            continue
+        relative = path.relative_to(staging_root).as_posix()
+        if certificate_offset == file_size and certificate_size > 0:
+            with path.open("r+b") as stream:
+                stream.seek(security_entry_offset)
+                stream.write(b"\0" * 8)
+            sanitized.append(relative)
+            continue
+        _require(
+            certificate_offset > 0 and certificate_size >= 8 and certificate_offset + certificate_size <= file_size,
+            f"msix_pe_certificate_table_corrupt:{relative}",
+        )
+    return tuple(sanitized)
+
+
+def prepare_layout(payload_root: Path, staging_root: Path, config: Mapping[str, Any]) -> tuple[str, ...]:
+    _copy_payload(payload_root, staging_root, config)
+    sanitized = _sanitize_stripped_pe_certificates(staging_root)
+    _write_assets(staging_root)
+    (staging_root / "AppxManifest.xml").write_text(render_manifest(config), encoding="utf-8", newline="\n")
+    return sanitized
+
+
+def _normalize_timestamps(root: Path, epoch: int) -> None:
+    paths = sorted(root.rglob("*"), key=lambda path: len(path.parts), reverse=True)
+    for path in paths:
+        os.utime(path, (epoch, epoch))
+    os.utime(root, (epoch, epoch))
+
+
+def _safe_reset_work_root(path: Path) -> Path:
+    resolved = path.resolve()
+    _require(resolved != Path(resolved.anchor), "msix_work_root_is_filesystem_root")
+    _require(resolved != Path.home().resolve(), "msix_work_root_is_home")
+    _require(len(resolved.parts) >= 3, "msix_work_root_too_broad")
+    if resolved.exists():
+        _require(resolved.is_dir() and not resolved.is_symlink(), "msix_work_root_invalid")
+        shutil.rmtree(resolved)
+    resolved.mkdir(parents=True)
+    return resolved
+
+
+def find_makeappx(explicit: Path | None = None) -> Path:
+    candidates: list[Path] = []
+    if explicit is not None:
+        candidates.append(explicit)
+    from_environment = os.environ.get("MAKEAPPX_EXE")
+    if from_environment:
+        candidates.append(Path(from_environment))
+
+    program_files_x86 = os.environ.get("PROGRAMFILES(X86)")
+    if program_files_x86:
+        sdk_bin = Path(program_files_x86) / "Windows Kits" / "10" / "bin"
+        if sdk_bin.is_dir():
+            candidates.extend(
+                sorted(sdk_bin.glob("10.*.*/x64/makeappx.exe"), key=lambda path: path.parts[-3], reverse=True)
+            )
+    on_path = shutil.which("makeappx.exe")
+    if on_path:
+        candidates.append(Path(on_path))
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise MsixBuildError("makeappx_not_found")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def package_content_identity(path: Path) -> tuple[int, str]:
+    """Hash package paths and uncompressed bytes while ignoring ZIP timestamps."""
+
+    package_digest = hashlib.sha256()
+    seen: set[str] = set()
+    with zipfile.ZipFile(path) as package:
+        entries = package.infolist()
+        for entry in entries:
+            _require(entry.filename not in seen, "msix_package_duplicate_entry")
+            seen.add(entry.filename)
+            name_bytes = entry.filename.encode("utf-8")
+            package_digest.update(len(name_bytes).to_bytes(4, "big"))
+            package_digest.update(name_bytes)
+            package_digest.update(entry.file_size.to_bytes(8, "big"))
+            entry_digest = hashlib.sha256()
+            with package.open(entry, "r") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    entry_digest.update(chunk)
+            package_digest.update(entry_digest.digest())
+    return len(entries), package_digest.hexdigest()
+
+
+def build_msix(
+    *,
+    payload_root: Path,
+    output: Path,
+    work_root: Path,
+    config: Mapping[str, Any],
+    makeappx: Path,
+) -> dict[str, object]:
+    safe_work_root = _safe_reset_work_root(work_root)
+    staging_root = safe_work_root / "staging"
+    sanitized_pe_certificates = prepare_layout(payload_root.resolve(), staging_root, config)
+    _normalize_timestamps(staging_root, int(config["reproducibilityEpoch"]))
+
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(
+        [str(makeappx), "pack", "/d", str(staging_root), "/p", str(output), "/o"],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.returncode != 0:
+        details = (completed.stdout + "\n" + completed.stderr).strip()
+        raise MsixBuildError(f"makeappx_failed:{completed.returncode}:{details}")
+    _require(output.is_file(), "msix_output_missing")
+    entry_count, content_sha256 = package_content_identity(output)
+
+    return {
+        "schemaVersion": 1,
+        "storeId": config["storeId"],
+        "identity": config["identity"],
+        "sourceVersion": config["sourceVersion"],
+        "packageVersion": config["packageVersion"],
+        "assetName": output.name,
+        "bytes": output.stat().st_size,
+        "sha256": _sha256(output),
+        "entryCount": entry_count,
+        "contentSha256": content_sha256,
+        "sanitizedPeCertificateDirectories": list(sanitized_pe_certificates),
+    }
+
+
+def _write_metadata(path: Path, metadata: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--payload-root", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    output_group = parser.add_mutually_exclusive_group(required=True)
+    output_group.add_argument("--output", type=Path)
+    output_group.add_argument("--output-root", type=Path)
+    parser.add_argument("--work-root", type=Path, required=True)
+    parser.add_argument("--source-version", required=True)
+    parser.add_argument("--makeappx", type=Path)
+    parser.add_argument("--metadata-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        config = read_config(args.config.resolve())
+        _require(args.source_version == config["sourceVersion"], "msix_source_version_mismatch")
+        output = args.output or (args.output_root / config["assetName"])
+        makeappx = find_makeappx(args.makeappx)
+        metadata = build_msix(
+            payload_root=args.payload_root,
+            output=output,
+            work_root=args.work_root,
+            config=config,
+            makeappx=makeappx,
+        )
+        if args.metadata_output is not None:
+            _write_metadata(args.metadata_output.resolve(), metadata)
+    except MsixBuildError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(metadata, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repo/test_msix_packaging.py
+++ b/tests/test_repo/test_msix_packaging.py
@@ -1,0 +1,192 @@
+"""Microsoft Store MSIX packaging contract tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree
+
+import pytest
+from PIL import Image
+from scripts.release import build_msix
+
+pytestmark = pytest.mark.contract
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_PATH = _REPO_ROOT / "release" / "windows-store-msix.v1.json"
+_FOUNDATION = "http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+_UAP5 = "http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+_RESCAP = "http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+
+
+def _fake_payload(path: Path) -> Path:
+    path.mkdir()
+    (path / "DocWen.exe").write_bytes(b"not-a-real-pe")
+    (path / "DocWenCLI.exe").write_bytes(b"not-a-real-pe")
+    assets = path / "assets"
+    assets.mkdir()
+    Image.new("RGBA", (256, 256), (38, 111, 227, 255)).save(assets / "icon.png")
+    docx_templates = path / "_internal" / "docx" / "templates"
+    expanded_template = docx_templates / "default-docx-template"
+    expanded_template.mkdir(parents=True)
+    (expanded_template / "[Content_Types].xml").write_text("reserved OPC part", encoding="utf-8")
+    (docx_templates / "default.docx").write_bytes(b"runtime-template")
+    return path
+
+
+def _fake_pe_with_certificate_directory(
+    path: Path,
+    *,
+    certificate_offset: int,
+    certificate_size: int,
+    file_size: int = 1024,
+) -> Path:
+    image = bytearray(file_size)
+    image[:2] = b"MZ"
+    pe_offset = 0x80
+    struct.pack_into("<I", image, 0x3C, pe_offset)
+    image[pe_offset : pe_offset + 4] = b"PE\0\0"
+    optional_size = 240
+    struct.pack_into("<H", image, pe_offset + 4 + 16, optional_size)
+    optional_offset = pe_offset + 24
+    struct.pack_into("<H", image, optional_offset, 0x20B)
+    struct.pack_into("<I", image, optional_offset + 108, 16)
+    struct.pack_into(
+        "<II",
+        image,
+        optional_offset + 112 + (4 * 8),
+        certificate_offset,
+        certificate_size,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(image)
+    return path
+
+
+def test_store_config_and_manifest_bind_partner_center_identity() -> None:
+    config = build_msix.read_config(_CONFIG_PATH)
+    manifest = ElementTree.fromstring(build_msix.render_manifest(config))
+    namespaces = {"f": _FOUNDATION, "uap5": _UAP5, "rescap": _RESCAP}
+
+    identity = manifest.find("f:Identity", namespaces)
+    assert identity is not None
+    assert identity.attrib == {
+        "Name": "ZHYX.DocWen",
+        "Publisher": "CN=9E46E7F1-F057-4B88-BF71-7C9CB77AF9C6",
+        "Version": "1.0.1.0",
+        "ProcessorArchitecture": "x64",
+    }
+    target = manifest.find("f:Dependencies/f:TargetDeviceFamily", namespaces)
+    assert target is not None and target.attrib["Name"] == "Windows.Desktop"
+    capability = manifest.find("f:Capabilities/rescap:Capability", namespaces)
+    assert capability is not None and capability.attrib["Name"] == "runFullTrust"
+    alias = manifest.find(".//uap5:ExecutionAlias", namespaces)
+    assert alias is not None and alias.attrib["Alias"] == "docwen.exe"
+
+
+@pytest.mark.parametrize("version", ["0.9.0.0", "1.0.0.1", "1.0.0", "65536.0.0.0"])
+def test_store_package_version_rejects_values_partner_center_will_reject(version: str) -> None:
+    with pytest.raises(build_msix.MsixBuildError):
+        build_msix.validate_package_version(version)
+
+
+def test_prepare_layout_keeps_payload_assets_and_generates_required_logos(tmp_path: Path) -> None:
+    config = build_msix.read_config(_CONFIG_PATH)
+    payload = _fake_payload(tmp_path / "payload")
+    staging = tmp_path / "staging"
+
+    build_msix.prepare_layout(payload, staging, config)
+
+    assert (staging / "DocWen.exe").read_bytes() == b"not-a-real-pe"
+    assert (staging / "AppxManifest.xml").is_file()
+    assert not (staging / "_internal" / "docx" / "templates" / "default-docx-template").exists()
+    assert (staging / "_internal" / "docx" / "templates" / "default.docx").is_file()
+    for name, expected_size in build_msix._ASSET_SIZES.items():  # pyright: ignore[reportPrivateUsage]
+        with Image.open(staging / "assets" / "msix" / name) as image:
+            assert image.size == expected_size
+
+
+def test_prepare_layout_clears_certificate_pointer_when_signature_blob_was_stripped(tmp_path: Path) -> None:
+    config = build_msix.read_config(_CONFIG_PATH)
+    payload = _fake_payload(tmp_path / "payload")
+    stripped = _fake_pe_with_certificate_directory(
+        payload / "_internal" / "tcl86t.dll",
+        certificate_offset=1024,
+        certificate_size=7408,
+    )
+    staging = tmp_path / "staging"
+
+    sanitized = build_msix.prepare_layout(payload, staging, config)
+
+    assert sanitized == ("_internal/tcl86t.dll",)
+    staged = (staging / stripped.relative_to(payload)).read_bytes()
+    security_entry_offset = 0x80 + 24 + 112 + (4 * 8)
+    assert struct.unpack_from("<II", staged, security_entry_offset) == (0, 0)
+
+
+def test_prepare_layout_rejects_partially_truncated_certificate_table(tmp_path: Path) -> None:
+    config = build_msix.read_config(_CONFIG_PATH)
+    payload = _fake_payload(tmp_path / "payload")
+    _fake_pe_with_certificate_directory(
+        payload / "_internal" / "broken.dll",
+        certificate_offset=1016,
+        certificate_size=16,
+    )
+
+    with pytest.raises(
+        build_msix.MsixBuildError,
+        match=r"msix_pe_certificate_table_corrupt:_internal/broken\.dll",
+    ):
+        build_msix.prepare_layout(payload, tmp_path / "staging", config)
+
+
+@pytest.mark.windows_only
+def test_makeappx_accepts_generated_layout_when_windows_sdk_is_available(tmp_path: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows-only MakeAppx contract")
+    try:
+        makeappx = build_msix.find_makeappx()
+    except build_msix.MsixBuildError:
+        pytest.skip("Windows SDK MakeAppx is unavailable")
+
+    config = build_msix.read_config(_CONFIG_PATH)
+    output = tmp_path / str(config["assetName"])
+    metadata = build_msix.build_msix(
+        payload_root=_fake_payload(tmp_path / "payload"),
+        output=output,
+        work_root=tmp_path / "work",
+        config=config,
+        makeappx=makeappx,
+    )
+
+    assert metadata["assetName"] == "DocWen-windows-x64.msix"
+    assert len(str(metadata["sha256"])) == 64
+    assert len(str(metadata["contentSha256"])) == 64
+    assert int(metadata["entryCount"]) > 5
+    with zipfile.ZipFile(output) as package:
+        names = set(package.namelist())
+        assert "AppxManifest.xml" in names
+        assert "assets/msix/StoreLogo.png" in names
+        assert "DocWen.exe" in names
+        assert "DocWenCLI.exe" in names
+
+
+def test_checked_in_store_config_is_stable_json() -> None:
+    config = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+    assert config["storeId"] == "9NR2211SJH97"
+    assert config["sourceVersion"] == "0.9.0"
+
+
+def test_package_content_identity_ignores_zip_timestamps(tmp_path: Path) -> None:
+    first = tmp_path / "first.msix"
+    second = tmp_path / "second.msix"
+    for path, timestamp in ((first, (2025, 1, 2, 3, 4, 6)), (second, (2026, 2, 3, 4, 5, 8))):
+        with zipfile.ZipFile(path, "w") as package:
+            entry = zipfile.ZipInfo("payload.txt", date_time=timestamp)
+            package.writestr(entry, b"same payload")
+
+    assert first.read_bytes() != second.read_bytes()
+    assert build_msix.package_content_identity(first) == build_msix.package_content_identity(second)

--- a/tests/test_repo/test_release_build_orchestration.py
+++ b/tests/test_repo/test_release_build_orchestration.py
@@ -163,7 +163,9 @@ def test_release_workflow_builds_each_supported_package_twice_and_runs_packaged_
     assert "--proofread-report-smoke" in windows_commands
     assert "verify_packaged_gui.py" in windows_commands
     assert "--settings-smoke" in windows_commands
-    assert windows_commands.count("if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }") == 3
+    assert "scripts/release/build_msix.py" in windows_commands
+    assert "windows-store-msix.v1.json" in windows_commands
+    assert windows_commands.count("if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }") == 4
     assert '$env:PYTHONUTF8 = "1"' in windows_commands
     assert '$env:PYTHONIOENCODING = "utf-8"' in windows_commands
 
@@ -238,6 +240,8 @@ def test_release_workflow_publishes_supported_windows_and_ubuntu_assets() -> Non
     project_metadata = Path("pyproject.toml").read_text(encoding="utf-8")
     assert "DocWenCLI-windows-x64.zip" not in workflow
     assert "DocWen-windows-x64.zip" in workflow
+    assert "DocWen-windows-x64.msix" in workflow
+    assert "docwen-microsoft-store-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
     assert "DocWenCLI-${RELEASE_VERSION}-linux-x64.tar.gz" in workflow
     assert "DocWen-${RELEASE_VERSION}-linux-x64.tar.gz" in workflow
     assert "DocWen-macos" not in workflow

--- a/tests/test_repo/test_release_build_script.py
+++ b/tests/test_repo/test_release_build_script.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import os
 import textwrap
 from pathlib import Path
 from unittest.mock import Mock
@@ -138,6 +139,29 @@ def test_pyinstaller_specs_follow_isolated_build_root(
 
     source = Path("scripts/build/build.py").read_text(encoding="utf-8")
     assert source.count("*_pyinstaller_output_args(),") == 2
+
+
+def test_windows_pyinstaller_path_excludes_ambient_native_toolchains(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts.build import build
+
+    system_root = tmp_path / "Windows"
+    (system_root / "System32").mkdir(parents=True)
+    foreign_native = tmp_path / "foreign-poppler" / "bin"
+    foreign_native.mkdir(parents=True)
+    original = os.pathsep.join((str(foreign_native), str(system_root / "System32")))
+    monkeypatch.setattr(build, "IS_WINDOWS", True)
+    monkeypatch.setenv("SYSTEMROOT", str(system_root))
+    monkeypatch.setenv("PATH", original)
+
+    with build._isolated_pyinstaller_path():  # pyright: ignore[reportPrivateUsage]
+        isolated = os.environ["PATH"].split(os.pathsep)
+        assert str(foreign_native) not in isolated
+        assert str(system_root / "System32") in isolated
+
+    assert os.environ["PATH"] == original
 
 
 def test_build_fails_closed_for_cleanup_and_cython_errors() -> None:


### PR DESCRIPTION
## Summary
- add deterministic Microsoft Store MSIX packaging
- sanitize invalid stripped PE certificate-directory entries before packaging
- publish MSIX and metadata from the release workflow
- isolate Windows PyInstaller builds from ambient native toolchains
- add packaging and release workflow tests

## Verification
- 34 targeted packaging and release tests passed
- git diff --check passed