### PR TITLE
fix: pin Linux release system dependency environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,11 @@ jobs:
     name: Clean Ubuntu build ${{ matrix.replica }}
     needs: release-gate
     runs-on: ubuntu-24.04
+    container:
+      image: mcr.microsoft.com/devcontainers/base:noble@sha256:24ea8d1abd543fb56208fa8f9468c9a684e65aa8c42d54f76e312127f1ed5cd9
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -197,10 +202,7 @@ jobs:
           enable-cache: true
       - name: Install Linux GUI dependencies
         shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends xvfb libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0
+        run: bash scripts/release/install_linux_build_dependencies.sh
       - name: Install exact lockfile
         run: uv sync --frozen --extra dev
       - name: Build GUI and CLI payloads

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -31,6 +31,10 @@ Windows 生产构建器把 PyInstaller 的 DLL 搜索路径限制为干净项目
 
 ## Release gates / 发布门禁
 
+Both Linux production builds run in the same digest-pinned Ubuntu 24.04 container declared in the release workflow. `scripts/release/install_linux_build_dependencies.sh` installs system dependencies from one dated Ubuntu archive snapshot and ignores other package repositories. Update the container digest and archive snapshot deliberately, then repeat both builds and extracted-package checks. The host runner's preinstalled libraries are not production build inputs.
+
+两次 Linux 生产构建均运行在发布工作流声明的同一固定摘要 Ubuntu 24.04 容器内。`scripts/release/install_linux_build_dependencies.sh` 从固定日期的 Ubuntu 仓库快照安装系统依赖，并忽略其他软件源。更新容器摘要或仓库快照后，必须重新执行两次构建及解压后包验证；宿主 runner 预装的库不作为生产构建输入。
+
 Repository settings must enable Immutable Releases and an active no-update/no-delete ruleset for numeric `x.y.z`
 tags before a version tag is pushed. 仓库设置必须在推送版本标签前启用 Immutable Releases，并启用禁止更新或
 删除数字 `x.y.z` 标签的 ruleset。

--- a/scripts/release/install_linux_build_dependencies.sh
+++ b/scripts/release/install_linux_build_dependencies.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Production builds use the workflow's immutable Ubuntu image and this archive snapshot.
+set -euo pipefail
+
+if [[ "$(id -u)" != 0 || ! -f /.dockerenv ]]; then
+  echo 'Linux release dependencies must be installed inside the release container.' >&2
+  exit 2
+fi
+
+source /etc/os-release
+if [[ "$ID" != ubuntu || "$VERSION_ID" != 24.04 || "$(dpkg --print-architecture)" != amd64 ]]; then
+  echo 'Linux release dependencies require Ubuntu 24.04 amd64.' >&2
+  exit 2
+fi
+
+sources=$(mktemp /tmp/docwen-ubuntu-sources-XXXXXX.sources)
+trap 'rm -f -- "$sources"' EXIT
+cat > "$sources" <<'SOURCES'
+Types: deb
+URIs: https://snapshot.ubuntu.com/ubuntu/20260909T000000Z/
+Suites: noble noble-updates noble-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+SOURCES
+
+# Ignore additional image repositories so they cannot influence dependency selection.
+apt_options=(-o "Dir::Etc::sourcelist=$sources" -o 'Dir::Etc::sourceparts=-')
+apt-get "${apt_options[@]}" update -qq
+DEBIAN_FRONTEND=noninteractive apt-get "${apt_options[@]}" install -y --no-install-recommends \
+  binutils xvfb xauth libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 \
+  libglib2.0-0t64 libfontconfig1 libnss3 libdbus-1-3 libgcrypt20 fonts-dejavu-core
+
+# Retain the resolved package versions in the immutable workflow log.
+dpkg-query -W -f='${binary:Package}\t${Version}\n' | LC_ALL=C sort

--- a/tests/test_repo/test_release_build_orchestration.py
+++ b/tests/test_repo/test_release_build_orchestration.py
@@ -177,7 +177,17 @@ def test_release_workflow_builds_each_supported_package_twice_and_runs_packaged_
     linux_dependency_step = next(
         step for step in linux["steps"] if step.get("name") == "Install Linux GUI dependencies"
     )
-    assert "libegl1" in linux_dependency_step["run"]
+    assert linux_dependency_step["run"] == "bash scripts/release/install_linux_build_dependencies.sh"
+    container = linux["container"]
+    assert isinstance(container, dict)
+    image = container["image"]
+    assert isinstance(image, str)
+    assert image.startswith("mcr.microsoft.com/devcontainers/base:noble@sha256:")
+    assert len(image.rsplit(":", 1)[1]) == 64
+    dependencies = Path("scripts/release/install_linux_build_dependencies.sh").read_text(encoding="utf-8")
+    assert "https://snapshot.ubuntu.com/ubuntu/" in dependencies
+    assert "Dir::Etc::sourceparts=-" in dependencies
+    assert "libegl1" in dependencies
 
     for job_name, job in jobs.items():
         assert isinstance(job, dict), job_name


### PR DESCRIPTION
The two Linux production builds could collect different host libraries when GitHub rolled its Ubuntu runner image. Preflight 34310794758 produced identical CLI archives, but its GUI archives differed in libgcrypt.so.20 and the generated hash manifests.

Run both Linux builds in one digest-pinned Ubuntu 24.04 container and install system dependencies from a fixed Ubuntu archive snapshot. Package selection excludes additional repositories, and resolved package versions remain in the workflow log. Both independent builds and extracted CLI/GUI checks remain mandatory.

Validation: tools/qa.py passed the required source checks and all 8 release orchestration regression tests. The container build and full publication preflight still require fresh CI evidence.
